### PR TITLE
IWHI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The --help parameter provides further information on how to use this along with 
 This CLI tool has been tested against
 * webMethods.io Integration v11.0.3
 
+This tool has also been used with IBM webMethods Hybrid Integration using the `--apikey` option to
+allow authentication to succeed in that environment.
+
 # License
 This project is licensed under the Apache 2.0 License - see the LICENSE file for details
 These tools are provided as-is and without warranty or support. They do not constitute part of the webMethods product suite. Users are free to use, fork and modify them, subject to the license agreement. While we welcome contributions, we cannot guarantee to include every contribution in the master project.
@@ -38,6 +41,7 @@ Options:
   -d, --domain <tenantDomain>                                                                                                                Tenant Doamin Name, e.g. "tenant.int-aws-us.webmethods.io"
   -u, --user <userid>                                                                                                                        Tenant User ID
   -p, --password <password>                                                                                                                  Tenant User Password
+  -k, --apikey <apikey>                                                                                                                    API key for X-INSTANCE-API-KEY header (replaces -u/-p)
   -s, --start <position>                                                                                                                     Index of where to start the return of data (default 0)
   -l, --count <count>                                                                                                                        Count of items to return (default 1000)
   -t, --timeout <delay>                                                                                                                      timeout in seconds (default: one minute)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wmiocli",
-  "version": "2024.11.1",
+  "version": "2025.7.17",
   "description": "webMethods.io Integration API CLI Tool",
   "bin": {
     "wmiocli": "./wmiocli.js"

--- a/projects.js
+++ b/projects.js
@@ -76,7 +76,7 @@ $ node wmiocli.js
     -d tenant.int-aws-us.webmethods.io 
     -u user 
     -p password 
-    project-export myproject.zip MyNewProjectName
+    project-import myproject.zip MyNewProjectName
 
 \x1b[32mGet Project Assets:\x1b[0m
 $ node wmiocli.js 

--- a/rest-fetch.js
+++ b/rest-fetch.js
@@ -156,10 +156,13 @@ async function uploadFileFormData(restEndPoint, user, pass, timeout, data, filen
     formData.append('field_separator', data.field_separator);
     formData.append('text_qualifier', data.text_qualifier);
 
+    const authHeaderName  = (user === 'X-INSTANCE-API-KEY') ? 'X-INSTANCE-API-KEY' : 'Authorization';
+    const authHeaderValue = (user === 'X-INSTANCE-API-KEY') ? pass : 'Basic ' + btoa(user + ':' + pass);
+
     const options = {
         method: method,
         headers: {
-            'Authorization': 'Basic ' + btoa(user + ':' + pass),
+            authHeaderName: authHeaderValue,
             'Accept': 'application/json',
             ...formData.getHeaders()
         },
@@ -321,12 +324,16 @@ async function custom(restEndPoint,user,pass,timeout,jsonBody,formBody,type,call
     //Authentication
     if(user!==undefined)
     {
-        options.auth={};
-        options.auth.username = user;
-        options.auth.password = pass;
-        const base64Credentials = Buffer.from(`${user}:${pass}`).toString('base64');
-        options.headers['Authorization']= `Basic ${base64Credentials}`;
-
+        if(user != "X-INSTANCE-API-KEY")
+        {
+            options.auth={};
+            options.auth.username = user;
+            options.auth.password = pass;
+            const base64Credentials = Buffer.from(`${user}:${pass}`).toString('base64');
+            options.headers['Authorization']= `Basic ${base64Credentials}`;
+        } else {
+            options.headers['X-INSTANCE-API-KEY'] = pass;
+        }
     }
 
     //Body Content

--- a/sync-rest-fetch.js
+++ b/sync-rest-fetch.js
@@ -138,10 +138,13 @@ async function uploadFileFormData(restEndPoint, user, pass, timeout, data, filen
     formData.append('field_separator', data.field_separator);
     formData.append('text_qualifier', data.text_qualifier);
 
+    const authHeaderName  = (user === 'X-INSTANCE-API-KEY') ? 'X-INSTANCE-API-KEY' : 'Authorization';
+    const authHeaderValue = (user === 'X-INSTANCE-API-KEY') ? pass : 'Basic ' + Buffer.from(user + ':' + pass).toString('base64');
+
     const options = {
         method: method,
         headers: {
-            'Authorization': 'Basic ' + Buffer.from(user + ':' + pass).toString('base64'),
+            authHeaderName: authHeaderValue,
             'Accept': 'application/json',
             ...formData.getHeaders()
         },
@@ -171,7 +174,11 @@ async function custom(restEndPoint, user, pass, timeout, data, contentType, meth
     };
 
     if(user!==undefined && user!==null && user.length>0){
-        options.headers["Authorization"]='Basic ' + Buffer.from(user + ':' + pass).toString('base64');
+        if ( user != "X-INSTANCE-API-KEY" ) {
+           options.headers["Authorization"]='Basic ' + Buffer.from(user + ':' + pass).toString('base64');
+        } else {
+           options.headers["X-INSTANCE-API-KEY"]=pass;
+        }
     }
 
     if (data) {
@@ -227,10 +234,13 @@ async function custom(restEndPoint, user, pass, timeout, data, contentType, meth
 async function downloadFile(restEndPoint, user, pass, timeout, destFile) {
     debug("GET File from: " + restEndPoint);
 
+    const authHeaderName  = (user === 'X-INSTANCE-API-KEY') ? 'X-INSTANCE-API-KEY' : 'Authorization';
+    const authHeaderValue = (user === 'X-INSTANCE-API-KEY') ? pass : 'Basic ' + Buffer.from(user + ':' + pass).toString('base64');
+
     const options = {
         method: 'GET',
         headers: {
-            'Authorization': 'Basic ' + Buffer.from(user + ':' + pass).toString('base64'),
+            authHeaderName: authHeaderValue,
             'Accept': 'application/octet-stream',
         },
         timeout: timeout * 1000,

--- a/wmiocli.js
+++ b/wmiocli.js
@@ -4,7 +4,7 @@
  * Apache-2.0
  */
 
-const versionNo = "2024.11.1"
+const versionNo = "2025.07.17"
 const { Command, Option } = require('commander');
 const { exit } = require('process');
 const readline = require('readline-sync');

--- a/wmiocli.js
+++ b/wmiocli.js
@@ -130,20 +130,27 @@ function checkOptions() {
     }
   }
 
-  if (program.opts().user == undefined) {
-    tenantUser = readFromConsole('Please type your tenant User ID: ');
+
+  if (program.opts().apikey == undefined) {
+    if (program.opts().user == undefined) {
+      tenantUser = readFromConsole('Please type your tenant User ID: ');
+    }
+    else {
+      tenantUser = program.opts().user
+    }
+
+    if (program.opts().password == undefined) {
+      tenantPw = readFromConsole('Please type your tenant User Password: ', true);
+    }
+    else {
+      tenantPw = program.opts().password
+    }
   }
   else {
-    tenantUser = program.opts().user
+    // Picked up in rest-fetch and used for the auth header
+    tenantUser = "X-INSTANCE-API-KEY"
+    tenantPw = program.opts().apikey
   }
-
-  if (program.opts().password == undefined) {
-    tenantPw = readFromConsole('Please type your tenant User Password: ', true);
-  }
-  else {
-    tenantPw = program.opts().password
-  }
-
 }
 
 function debug(message) {
@@ -158,10 +165,11 @@ program
   .version(versionNo)
 
   //required options
-  .option('-d, --domain <tenantDomain>', 'Tenant Doamin Name, e.g. "tenant.int-aws-us.webmethods.io"')
+  .option('-d, --domain <tenantDomain>', 'Tenant Domain Name, e.g. "tenant.int-aws-us.webmethods.io"')
   .option('-u, --user <userid>', 'Tenant User ID')
   .option('-p, --password <password>', 'Tenant User Password')
   //.requiredOption('-p, --password <password>', 'Tenant User Password')
+  .option('-k, --apikey <apikey>', 'API key for X-INSTANCE-API-KEY header (replaces -u/-p)')
 
   //Positional optoins
   .option('-s, --start <position>', 'Index of where to start the return of data (default 0)')

--- a/wmiocli.js
+++ b/wmiocli.js
@@ -4,7 +4,7 @@
  * Apache-2.0
  */
 
-const versionNo = "2025.07.17"
+const versionNo = "2025.7.17"
 const { Command, Option } = require('commander');
 const { exit } = require('process');
 const readline = require('readline-sync');


### PR DESCRIPTION
IBM webMethods Hybrid Integration (IWHI) uses a slightly different model for authentication, and the simplest way to make the CLI work is to use an API key; this involves sending the API key in the `X-INSTANCE-API-KEY` header instead of the usual basic auth, and the rest of the CLI then appears to work as expected.